### PR TITLE
Prevent undefined index error 

### DIFF
--- a/wp-content/plugins/gocardless/admin.php
+++ b/wp-content/plugins/gocardless/admin.php
@@ -73,7 +73,7 @@ function gocardless_admin_dashboard() {
 
     // Add bill count to each subscription
     foreach ($raw_bills as $key => $value) {
-      if (is_object($subscriptions[$value->source_id])) {
+      if (isset($subscriptions[$value->source_id]) && is_object($subscriptions[$value->source_id])) {
         $subscriptions[$value->source_id]->bill_count++;
       }
     }


### PR DESCRIPTION
When debug mode is on the "undefined index error" message sometimes occurs, checking if the variable is first set fixes this.
